### PR TITLE
Add readline module

### DIFF
--- a/builtins.json
+++ b/builtins.json
@@ -17,6 +17,7 @@
   "path",
   "punycode",
   "querystring",
+  "readline",
   "repl",
   "stream",
   "string_decoder",


### PR DESCRIPTION
List the "readline"-module as a built in module.

Module documented in:

io.js: https://iojs.org/api/readline.html 
Node 0.10: http://nodejs.org/dist/v0.10.37/docs/api/readline.html
Node 0.12: https://nodejs.org/api/readline.html