### PR TITLE
Prevent the publication of unwanted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "juliangruber/builtins",
   "license": "MIT",
   "main": "index.js",
+  "files": [],
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
Hi,

This pull-request add an empty files field in the package (this is a field to whitelist file for publication).
https://docs.npmjs.com/files/package.json#files

this prevent the following files to being published in the npm tarball:
- travis.yml
- gitignore
- test.js

I know that some package author want to include their test as a kind of documentation but your package as being detected as a security threat by one of the tool i [work on](https://github.com/ES-Community/nsecure) because of the following code in test.js
```js
test('default to current version', function (t) {
  builtins().forEach(function (name) {
    t.ok(require(name), name) // My AST analysis is not capable to follow here so it flag the package as dangerous
  })
  t.end()
})
```

I guess the project README is enough here so they will be no problem for removing test from npm package tarball ?

> Note: I also recommend removing History.md.. this file doesn't seem to be updated since few years.

Thanks

Best Regards,
Thomas