### PR TITLE
perf: initialization and builins creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const semver = require('semver')
+const satisfies = require('semver/functions/satisfies')
 
 const permanentModules = [
   'assert',
@@ -60,7 +60,7 @@ module.exports = ({ version = process.version, experimental = false } = {}) => {
   const builtins = [...permanentModules]
 
   for (const [name, semverRange] of Object.entries(versionLockedModules)) {
-    if (version === '*' || semver.satisfies(version, semverRange)) {
+    if (version === '*' || satisfies(version, semverRange)) {
       builtins.push(name)
     }
   }
@@ -69,7 +69,7 @@ module.exports = ({ version = process.version, experimental = false } = {}) => {
     for (const [name, semverRange] of Object.entries(experimentalModules)) {
       if (
         !builtins.includes(name) &&
-        (version === '*' || semver.satisfies(version, semverRange))
+        (version === '*' || satisfies(version, semverRange))
       ) {
         builtins.push(name)
       }

--- a/index.js
+++ b/index.js
@@ -37,39 +37,38 @@ const permanentModules = [
   'zlib'
 ]
 
-const versionLockedModules = {
-  freelist: '<6.0.0',
-  v8: '>=1.0.0',
-  process: '>=1.1.0',
-  inspector: '>=8.0.0',
-  async_hooks: '>=8.1.0',
-  http2: '>=8.4.0',
-  perf_hooks: '>=8.5.0',
-  trace_events: '>=10.0.0',
-  worker_threads: '>=12.0.0',
-  'node:test': '>=18.0.0'
-}
+const versionLockedModules = [
+  'node:test', 'worker_threads', 'trace_events', 'perf_hooks', 'http2', 'async_hooks', 'inspector', 'process', 'v8'
+]
+const versionLockedModulesRange = [
+  '>=18.0.0', '>=12.0.0', '>=10.0.0', '>=8.5.0', '>=8.4.0', '>=8.1.0', '>=8.0.0', '>=1.1.0', '>=1.0.0'
+]
 
-const experimentalModules = {
-  worker_threads: '>=10.5.0',
-  wasi: '>=12.16.0',
-  diagnostics_channel: '^14.17.0 || >=15.1.0'
-}
+const experimentalModulesRanges = [
+  '^14.17.0 || >=15.1.0', '>=12.16.0', '>=10.5.0'
+]
+const experimentalModules = ['diagnostics_channel', 'wasi', 'worker_threads']
 
 module.exports = ({ version = process.version, experimental = false } = {}) => {
-  const builtins = [...permanentModules]
+  const builtins = permanentModules.slice()
 
-  for (const [name, semverRange] of Object.entries(versionLockedModules)) {
-    if (version === '*' || satisfies(version, semverRange)) {
-      builtins.push(name)
+  for (let i = 0; i < versionLockedModulesRange.length; i++) {
+    if (version === '*' || satisfies(version, versionLockedModulesRange[i])) {
+      Array.prototype.push.apply(builtins, versionLockedModules.slice(i))
+      break
     }
   }
 
+  if (version === '*' || satisfies(version, '<6.0.0')) {
+    builtins.push('freelist')
+  }
+
   if (experimental) {
-    for (const [name, semverRange] of Object.entries(experimentalModules)) {
+    for (let i = 0; i < experimentalModulesRanges.length; i++) {
+      const name = experimentalModules[i]
       if (
         !builtins.includes(name) &&
-        (version === '*' || satisfies(version, semverRange))
+        (version === '*' || satisfies(version, experimentalModulesRanges[i]))
       ) {
         builtins.push(name)
       }


### PR DESCRIPTION
Tiny optimizations to avoid memory allocation and also reduce the initialization time of this module by only importing `satisfies`:

Before:

```
* x 1,433,739 ops/sec ±0.83% (87 runs sampled)
20.0.0 x 92,502 ops/sec ±0.32% (98 runs sampled)
19.0.0 x 90,701 ops/sec ±0.91% (95 runs sampled)
18.0.0 x 91,888 ops/sec ±0.74% (100 runs sampled)
17.0.0 x 91,084 ops/sec ±1.20% (96 runs sampled)
16.0.0 x 92,002 ops/sec ±0.15% (99 runs sampled)
15.0.0 x 89,858 ops/sec ±0.50% (99 runs sampled)
14.0.0 x 91,788 ops/sec ±0.65% (84 runs sampled)
12.0.0 x 92,606 ops/sec ±0.70% (97 runs sampled)
10.0.0 x 85,059 ops/sec ±0.89% (94 runs sampled)
```

After

```
* x 6,552,727 ops/sec ±0.32% (94 runs sampled)
20.0.0 x 247,181 ops/sec ±0.05% (95 runs sampled)
19.0.0 x 246,650 ops/sec ±0.32% (99 runs sampled)
18.0.0 x 250,804 ops/sec ±0.13% (97 runs sampled)
17.0.0 x 202,482 ops/sec ±0.05% (99 runs sampled)
16.0.0 x 202,364 ops/sec ±0.08% (98 runs sampled)
15.0.0 x 195,289 ops/sec ±0.41% (97 runs sampled)
14.0.0 x 204,489 ops/sec ±0.04% (98 runs sampled)
12.0.0 x 207,687 ops/sec ±0.13% (98 runs sampled)
10.0.0 x 155,821 ops/sec ±0.16% (98 runs sampled)
```

Benchmark:

```js
import builtins from './index.js'
import benchmark from 'benchmark'

const suite = benchmark.Suite()

for (const version of ['*', '20.0.0', '19.0.0', '18.0.0', '17.0.0', '16.0.0', '15.0.0', '14.0.0', '12.0.0', '10.0.0']) {
  suite.add(version, () => {
    return builtins({ version, experimental: true })
  })
}

suite
  .on('cycle', event => {
    console.log(event.target.toString())
  })
  .run()
```